### PR TITLE
Actualización tablas después de hacer POST/PUT

### DIFF
--- a/src/components/actividades/AltaModificacionActividad.js
+++ b/src/components/actividades/AltaModificacionActividad.js
@@ -16,6 +16,7 @@ import { create, update } from '../../helpers/fetchApi';
 
 import { PropTypes } from 'prop-types';
 import { actividadPorId } from '../../state/actividades';
+import { useNotificarActualizacion } from '../../state/actualizaciones';
 import { dateFormatter } from '../../utils/dateUtils';
 import { todosLosEspacios } from '../../state/espacios';
 import { Link, useParams } from 'react-router-dom';
@@ -26,6 +27,7 @@ export default function AltaActividad(props) {
   const { id } = useParams();
   const { titulo } = props;
   const actividadDB = useRecoilValue(actividadPorId(id));
+  const notificarActualizacion = useNotificarActualizacion('actividades');
 
   const [actividad, setActividad] = useState(actividadDB.data);
   const {
@@ -46,10 +48,15 @@ export default function AltaActividad(props) {
     });
   };
 
-  const saveData = () => {
-    id !== undefined
-      ? update(`actividades/${id}`, actividad)
-      : create('actividades', actividad);
+  const saveData = async () => {
+    if (id !== undefined) {
+      await update(`espacios/${id}`, actividad);
+    } else {
+      await create('espacios', actividad);
+    }
+
+    notificarActualizacion();
+    history.push('/espacios');
   };
 
   const espacios = useRecoilValue(todosLosEspacios);
@@ -249,13 +256,7 @@ export default function AltaActividad(props) {
 
         <Grid container item xs={12} align="center" spacing={3}>
           <Grid item xs={6} align="right">
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={saveData}
-              component={Link}
-              to="/actividades"
-            >
+            <Button variant="contained" color="primary" onClick={saveData}>
               {!id ? 'Guardar' : 'Actualizar'}
             </Button>
           </Grid>

--- a/src/components/actividades/AltaModificacionActividad.js
+++ b/src/components/actividades/AltaModificacionActividad.js
@@ -19,7 +19,7 @@ import { actividadPorId } from '../../state/actividades';
 import { useNotificarActualizacion } from '../../state/actualizaciones';
 import { dateFormatter } from '../../utils/dateUtils';
 import { todosLosEspacios } from '../../state/espacios';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useHistory, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { useState } from 'react';
 
@@ -28,6 +28,7 @@ export default function AltaActividad(props) {
   const { titulo } = props;
   const actividadDB = useRecoilValue(actividadPorId(id));
   const notificarActualizacion = useNotificarActualizacion('actividades');
+  const history = useHistory();
 
   const [actividad, setActividad] = useState(actividadDB.data);
   const {
@@ -50,13 +51,13 @@ export default function AltaActividad(props) {
 
   const saveData = async () => {
     if (id !== undefined) {
-      await update(`espacios/${id}`, actividad);
+      await update(`actividades/${id}`, actividad);
     } else {
-      await create('espacios', actividad);
+      await create('actividades', actividad);
     }
 
     notificarActualizacion();
-    history.push('/espacios');
+    history.push('/actividades');
   };
 
   const espacios = useRecoilValue(todosLosEspacios);

--- a/src/components/actividades/ListadoActividades.js
+++ b/src/components/actividades/ListadoActividades.js
@@ -39,10 +39,10 @@ export default function ListadoActividades() {
   const actividades = useRecoilValue(todasLasActividades);
 
   const [abrirModal, setAbrirModal] = useState(false);
-  const [idActividadAEliminar, setIdActividadAEliminar] = useState();
+  const [actividadAEliminar, setActividadAEliminar] = useState();
 
-  const eliminarActividad = (idActividad) => {
-    setIdActividadAEliminar(idActividad);
+  const eliminarActividad = (actividad) => {
+    setActividadAEliminar(actividad);
     setAbrirModal(true);
   };
 
@@ -85,7 +85,7 @@ export default function ListadoActividades() {
                     </IconButton>
                     <IconButton className={classes.icon} aria-label="delete">
                       <DeleteIcon
-                        onClick={() => eliminarActividad(actividad.id)}
+                        onClick={() => eliminarActividad(actividad)}
                       />
                     </IconButton>
                   </TableCell>
@@ -111,7 +111,7 @@ export default function ListadoActividades() {
         abrirModal={abrirModal}
         setAbrirModal={setAbrirModal}
         ruta={'actividades'}
-        idEntidadAEliminar={idActividadAEliminar}
+        entidadAEliminar={actividadAEliminar}
       />
     </>
   );

--- a/src/components/actividades/ListadoActividades.js
+++ b/src/components/actividades/ListadoActividades.js
@@ -36,8 +36,7 @@ export default function ListadoActividades() {
 
   const classes = useStyles();
 
-  const listaActividades = useRecoilValue(todasLasActividades);
-  const [actividades, setActividades] = useState(listaActividades);
+  const actividades = useRecoilValue(todasLasActividades);
 
   const [abrirModal, setAbrirModal] = useState(false);
   const [idActividadAEliminar, setIdActividadAEliminar] = useState();
@@ -112,8 +111,6 @@ export default function ListadoActividades() {
         abrirModal={abrirModal}
         setAbrirModal={setAbrirModal}
         ruta={'actividades'}
-        entidades={actividades}
-        setEntidades={setActividades}
         idEntidadAEliminar={idActividadAEliminar}
       />
     </>

--- a/src/components/espacios/AltaModificacionEspacio.js
+++ b/src/components/espacios/AltaModificacionEspacio.js
@@ -12,11 +12,12 @@ import {
   TextField,
   Typography,
 } from '@material-ui/core';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useHistory, useParams } from 'react-router-dom';
 import { create, update } from '../../helpers/fetchApi';
 
 import PropTypes from 'prop-types';
 import { espacioPorId } from '../../state/espacios';
+import { useNotificarActualizacion } from '../../state/actualizaciones';
 import { todosLosEdificios } from '../../state/edificio';
 import { useRecoilValue } from 'recoil';
 import { useState } from 'react';
@@ -26,6 +27,8 @@ export default function Espacio(props) {
   const { titulo } = props;
   const espacioDB = useRecoilValue(espacioPorId(id)).data;
   const edificiosDB = useRecoilValue(todosLosEdificios);
+  const history = useHistory();
+  const notificarActualizacion = useNotificarActualizacion('espacios');
 
   const [espacio, setEspacio] = useState(espacioDB);
 
@@ -36,10 +39,15 @@ export default function Espacio(props) {
     });
   };
 
-  const saveData = () => {
-    id !== undefined
-      ? update(`espacios/${id}`, espacio)
-      : create('espacios', espacio);
+  const saveData = async () => {
+    if (id !== undefined) {
+      await update(`espacios/${id}`, espacio);
+    } else {
+      await create('espacios', espacio);
+    }
+
+    notificarActualizacion();
+    history.push('/espacios');
   };
 
   return (
@@ -159,13 +167,7 @@ export default function Espacio(props) {
         </Box>
 
         <Box mt={5}>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={saveData}
-            component={Link}
-            to="/espacios"
-          >
+          <Button variant="contained" color="primary" onClick={saveData}>
             Guardar
           </Button>
           <Button component={Link} to="/espacios">

--- a/src/components/espacios/ListadoEspacios.js
+++ b/src/components/espacios/ListadoEspacios.js
@@ -35,8 +35,7 @@ export default function PantallaEspacios() {
 
   const classes = useStyles();
 
-  const listaEspacios = useRecoilValue(todosLosEspacios);
-  const [espacios, setEspacios] = useState(listaEspacios);
+  const espacios = useRecoilValue(todosLosEspacios);
 
   const [abrirModal, setAbrirModal] = useState(false);
   const [idEspacioAEliminar, setIdEspacioAEliminar] = useState();
@@ -115,8 +114,6 @@ export default function PantallaEspacios() {
         abrirModal={abrirModal}
         setAbrirModal={setAbrirModal}
         ruta={'espacios'}
-        entidades={espacios}
-        setEntidades={setEspacios}
         idEntidadAEliminar={idEspacioAEliminar}
       />
     </>

--- a/src/components/espacios/ListadoEspacios.js
+++ b/src/components/espacios/ListadoEspacios.js
@@ -38,10 +38,10 @@ export default function PantallaEspacios() {
   const espacios = useRecoilValue(todosLosEspacios);
 
   const [abrirModal, setAbrirModal] = useState(false);
-  const [idEspacioAEliminar, setIdEspacioAEliminar] = useState();
+  const [espacioAEliminar, setEspacioAEliminar] = useState();
 
-  const eliminarEspacio = (idEspacio) => {
-    setIdEspacioAEliminar(idEspacio);
+  const eliminarEspacio = (espacio) => {
+    setEspacioAEliminar(espacio);
     setAbrirModal(true);
   };
 
@@ -89,7 +89,7 @@ export default function PantallaEspacios() {
                       <CreateIcon />
                     </IconButton>
                     <IconButton className={classes.icon} aria-label="delete">
-                      <DeleteIcon onClick={() => eliminarEspacio(espacio.id)} />
+                      <DeleteIcon onClick={() => eliminarEspacio(espacio)} />
                     </IconButton>
                   </TableCell>
                 </TableRow>
@@ -114,7 +114,7 @@ export default function PantallaEspacios() {
         abrirModal={abrirModal}
         setAbrirModal={setAbrirModal}
         ruta={'espacios'}
-        idEntidadAEliminar={idEspacioAEliminar}
+        entidadAEliminar={espacioAEliminar}
       />
     </>
   );

--- a/src/components/ui/ConfirmarEliminacion.js
+++ b/src/components/ui/ConfirmarEliminacion.js
@@ -7,9 +7,12 @@ import React from 'react';
 import { deleteById } from '../../helpers/fetchApi';
 import { useNotificarActualizacion } from '../../state/actualizaciones';
 
-export default function VentanaModal(props) {
-  const { abrirModal, setAbrirModal, ruta, idEntidadAEliminar } = props;
-
+export default function ConfirmarEliminacion({
+  abrirModal,
+  setAbrirModal,
+  ruta,
+  entidadAEliminar,
+}) {
   const notificarActualizacion = useNotificarActualizacion(ruta);
 
   const cerrarModal = () => {
@@ -17,7 +20,7 @@ export default function VentanaModal(props) {
   };
 
   const eliminar = async () => {
-    await deleteById(ruta, idEntidadAEliminar);
+    await deleteById(ruta, entidadAEliminar.id);
     notificarActualizacion();
     cerrarModal();
   };
@@ -29,17 +32,14 @@ export default function VentanaModal(props) {
       open={abrirModal}
     >
       <DialogTitle id="alert-dialog-slide-title">
-        {'¿Está seguro que desea borrar?'}
+        ¿Confirma que desea eliminar <strong>{entidadAEliminar?.nombre}</strong>
+        ?
       </DialogTitle>
       <DialogActions>
-        <Button variant="contained" onClick={() => cerrarModal()}>
+        <Button variant="contained" onClick={cerrarModal}>
           Cancelar
         </Button>
-        <Button
-          variant="contained"
-          color="secondary"
-          onClick={() => eliminar()}
-        >
+        <Button variant="contained" color="secondary" onClick={eliminar}>
           Borrar
         </Button>
       </DialogActions>
@@ -47,9 +47,12 @@ export default function VentanaModal(props) {
   );
 }
 
-VentanaModal.propTypes = {
+ConfirmarEliminacion.propTypes = {
   abrirModal: PropTypes.bool,
   setAbrirModal: PropTypes.func,
   ruta: PropTypes.string,
-  idEntidadAEliminar: PropTypes.number,
+  entidadAEliminar: PropTypes.shape({
+    id: PropTypes.number,
+    nombre: PropTypes.string,
+  }),
 };

--- a/src/components/ui/ConfirmarEliminacion.js
+++ b/src/components/ui/ConfirmarEliminacion.js
@@ -5,31 +5,20 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { deleteById } from '../../helpers/fetchApi';
+import { useNotificarActualizacion } from '../../state/actualizaciones';
 
 export default function VentanaModal(props) {
-  const {
-    abrirModal,
-    setAbrirModal,
-    ruta,
-    entidades,
-    setEntidades,
-    idEntidadAEliminar,
-  } = props;
+  const { abrirModal, setAbrirModal, ruta, idEntidadAEliminar } = props;
+
+  const notificarActualizacion = useNotificarActualizacion(ruta);
 
   const cerrarModal = () => {
     setAbrirModal(false);
   };
 
-  const eliminar = () => {
-    deleteById(ruta, idEntidadAEliminar)
-      .then(() => {
-        const items = entidades.filter(
-          (entidad) => idEntidadAEliminar !== entidad.id
-        );
-        setEntidades(items);
-      })
-      .catch((error) => console.log(error));
-
+  const eliminar = async () => {
+    await deleteById(ruta, idEntidadAEliminar);
+    notificarActualizacion();
     cerrarModal();
   };
 
@@ -62,7 +51,5 @@ VentanaModal.propTypes = {
   abrirModal: PropTypes.bool,
   setAbrirModal: PropTypes.func,
   ruta: PropTypes.string,
-  entidades: PropTypes.array,
-  setEntidades: PropTypes.func,
   idEntidadAEliminar: PropTypes.number,
 };

--- a/src/state/actividades.js
+++ b/src/state/actividades.js
@@ -2,10 +2,15 @@ import { selector, selectorFamily } from 'recoil';
 import { DateTime } from 'luxon';
 import { getData } from '../helpers/fetchApi';
 import { dateFormatter } from '../utils/dateUtils';
+import { contadorActualizacionesState } from './actualizaciones';
 
 export const todasLasActividades = selector({
   key: 'todasLasActividades',
-  get: async () => (await getData('actividades')).data,
+  get: async ({ get }) => {
+    get(contadorActualizacionesState('actividades'));
+    const { data } = await getData('actividades');
+    return data;
+  },
 });
 
 export const actividadPorId = selectorFamily({

--- a/src/state/actividades.js
+++ b/src/state/actividades.js
@@ -15,8 +15,9 @@ export const todasLasActividades = selector({
 
 export const actividadPorId = selectorFamily({
   key: 'actividadPorId',
-  get: (id) => async () =>
-    id !== undefined
+  get: (id) => async ({ get }) => {
+    get(contadorActualizacionesState('actividades'));
+    return id !== undefined
       ? await getData(`actividades/${id}`)
       : {
           data: {
@@ -29,5 +30,6 @@ export const actividadPorId = selectorFamily({
             tipoResponsable: '',
             estado: false,
           },
-        },
+        };
+  },
 });

--- a/src/state/actualizaciones.js
+++ b/src/state/actualizaciones.js
@@ -1,0 +1,15 @@
+import { atomFamily, useSetRecoilState } from 'recoil';
+
+export const contadorActualizacionesState = atomFamily({
+  key: 'contadorActualizaciones',
+  default: 0,
+});
+
+export function useNotificarActualizacion(nombreEntidad) {
+  const setContador = useSetRecoilState(
+    contadorActualizacionesState(nombreEntidad)
+  );
+  return () => {
+    setContador((contador) => contador + 1);
+  };
+}

--- a/src/state/espacios.js
+++ b/src/state/espacios.js
@@ -1,10 +1,15 @@
 import { selector, selectorFamily } from 'recoil';
 
 import { getData } from '../helpers/fetchApi';
+import { contadorActualizacionesState } from './actualizaciones';
 
 export const todosLosEspacios = selector({
   key: 'todosLosEspacios',
-  get: async () => (await getData('espacios')).data,
+  get: async ({ get }) => {
+    get(contadorActualizacionesState('espacios'));
+    const { data } = await getData('espacios');
+    return data;
+  },
 });
 
 export const espacioPorId = selectorFamily({

--- a/src/state/espacios.js
+++ b/src/state/espacios.js
@@ -14,8 +14,9 @@ export const todosLosEspacios = selector({
 
 export const espacioPorId = selectorFamily({
   key: 'espacioPorId',
-  get: (id) => async () =>
-    id !== undefined
+  get: (id) => async ({ get }) => {
+    get(contadorActualizacionesState('espacios'));
+    return id !== undefined
       ? await getData(`espacios/${id}`)
       : {
           data: {
@@ -25,5 +26,6 @@ export const espacioPorId = selectorFamily({
             piso: '',
             habilitado: 'true',
           },
-        },
+        };
+  },
 });


### PR DESCRIPTION
Closes unahur-covid/planificacion#34

Les dejo algunos comentarios en el código para que entiendan qué es lo que hice. Habría que imitarlo en futuras funcionalidades.

De yapa, agregué algo al diálogo de confirmación que, a mi parecer, mejora la experiencia de usuario:

![Peek 2021-01-14 16-45](https://user-images.githubusercontent.com/1585835/104640996-f5d6c980-5687-11eb-880b-0ec68fa6db1a.gif)

