### PR TITLE
Registro: clave inválida impide saber formato

### DIFF
--- a/src/components/ErroresText/Errores.js
+++ b/src/components/ErroresText/Errores.js
@@ -4,7 +4,8 @@ const ERRORES = {
   dni: 'Ingrese un DNI válido',
   email: 'Ingrese un email válido.',
   telefono: 'Ingrese un número válido',
-  contrasenia: 'Ingrese un formato válido',
+  contrasenia:
+    'Contraseña inválida, debe tener un mínimo de 8 caracteres, con minúsculas, mayúsculas y números',
   contraseniasNoCoinciden: 'Las contraseñas no coinciden.',
   mensajeDeError: 'Puede que los datos ingresados ya esten siendo ocupados.',
   requerido: 'Este campo es requerido',


### PR DESCRIPTION
Closes unahur-covid/planificacion#55

![image](https://user-images.githubusercontent.com/48968618/107444166-dca32a80-6b18-11eb-870f-b210184bdb6d.png)

